### PR TITLE
Add missing pipe

### DIFF
--- a/templates/secrets/smtp.yaml
+++ b/templates/secrets/smtp.yaml
@@ -7,5 +7,5 @@ metadata:
 {{ include "appwrite.labels" $ | indent 4 }}
 type: Opaque
 data:
-  _APP_SMTP_USERNAME: {{ .Values.smtp.user | b64enc }}
-  _APP_SMTP_PASSWORD: {{ .Values.smtp.pass | b64enc }}
+  _APP_SMTP_USERNAME: {{ .Values.smtp.user | b64enc | quote }}
+  _APP_SMTP_PASSWORD: {{ .Values.smtp.pass | b64enc | quote }}


### PR DESCRIPTION
Hello,

I noticed that on a first run, there was an issue for some `_APP_SMTP_*` env vars

```
Error: unable to build kubernetes objects from release manifest: 
error validating "": 
error validating data: [unknown object type "nil" in Secret.data._APP_SMTP_PASSWORD, unknown object type "nil" in Secret.data._APP_SMTP_USERNAME]
```

Since Helm v3, default values have to be set, as it handles differently 
One way to fix that is to add a `| quote` when an empty string is passed by

the diff is really short, I let you have a look.
With this fix, I didn't have anymore `_APP_SMTP_*` env vars error during first install run