### PR TITLE
Fiv env.yaml ReadString error

### DIFF
--- a/templates/config/env.yaml
+++ b/templates/config/env.yaml
@@ -10,8 +10,8 @@ data:
   _APP_CONSOLE_WHITELIST_IPS: {{ include "array.join" .Values.appwrite.console.whitelist.ips }}
   _APP_CONSOLE_WHITELIST_ROOT: {{ include "boolToStr" .Values.appwrite.console.whitelist.root }}
   _APP_DB_USER: {{ .Values.mariadb.auth.username }}
-  _APP_DB_PORT: {{ "3306" }}
-  _APP_DB_SCHEMA: {{ "appwrite" }}
+  _APP_DB_PORT: "3306"
+  _APP_DB_SCHEMA: "appwrite"
   _APP_DB_HOST: {{ include "appwrite.fullname" . | printf "%s-mariadb" }}
   _APP_DOMAIN: {{ .Values.appwrite.domain | quote }}
   _APP_DOMAIN_TARGET: {{ .Values.appwrite.domain | quote }}


### PR DESCRIPTION
I noticed a ReadString error when installing the helm chart
The error as it's shown:

* ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|DB_PORT":3306,"_APP_|..., bigger context ...|"_APP_DB_HOST":"appwrite-mariadb","_APP_DB_PORT":3306,"_APP_DB_SCHEMA":"appwrite","_APP_DB_USER":"ap|...

I think I'ts due at the way these two variables are handled by default on the actual branch:
```
  _APP_DB_PORT: {{ "3306" }}
  _APP_DB_SCHEMA: {{ "appwrite" }}
```

The diff is really short, I let you have a look. I think it's a typo in the env.yaml. 
These env vars shloud not be interpreted, but should just be strings
(unless you want them to be customizable in the Values)