### PR TITLE
fix: quote db port

### DIFF
--- a/templates/config/env.yaml
+++ b/templates/config/env.yaml
@@ -10,7 +10,7 @@ data:
   _APP_CONSOLE_WHITELIST_IPS: {{ include "array.join" .Values.appwrite.console.whitelist.ips }}
   _APP_CONSOLE_WHITELIST_ROOT: {{ include "boolToStr" .Values.appwrite.console.whitelist.root }}
   _APP_DB_USER: {{ .Values.mariadb.auth.username }}
-  _APP_DB_PORT: {{ "3306" }}
+  _APP_DB_PORT: {{ "3306" | quote }}
   _APP_DB_SCHEMA: {{ "appwrite" }}
   _APP_DB_HOST: {{ include "appwrite.fullname" . | printf "%s-mariadb" }}
   _APP_DOMAIN: {{ .Values.appwrite.domain | quote }}


### PR DESCRIPTION
Fixes parse error which appears on `helm upgrade`.
```
Error: UPGRADE FAILED: failed to create resource: ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string
helm.go:84: [debug] ConfigMap in version "v1" cannot be handled as a ConfigMap: json: cannot unmarshal number into Go struct field ConfigMap.data of type string
failed to create resource
helm.sh/helm/v3/pkg/kube.(*Client).Update.func1
	helm.sh/helm/v3/pkg/kube/client.go:414
helm.sh/helm/v3/pkg/kube.ResourceList.Visit
	helm.sh/helm/v3/pkg/kube/resource.go:32
helm.sh/helm/v3/pkg/kube.(*Client).Update
	helm.sh/helm/v3/pkg/kube/client.go:398
helm.sh/helm/v3/pkg/action.(*Upgrade).releasingUpgrade
	helm.sh/helm/v3/pkg/action/upgrade.go:384
runtime.goexit
	runtime/asm_amd64.s:1598
UPGRADE FAILED
```